### PR TITLE
Allow filtering on list endpoint

### DIFF
--- a/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalOrganisationEndPoints.cs
+++ b/src/FamilyHubs.ServiceDirectory.Api/Endpoints/MinimalOrganisationEndPoints.cs
@@ -56,11 +56,11 @@ public class MinimalOrganisationEndPoints
             }
         }).WithMetadata(new SwaggerOperationAttribute("Get Organisation Code By Organisation Id", "Get Organisation Code By Organisation Id") { Tags = new[] { "Organisations" } });
 
-        app.MapGet("api/organisations", async (CancellationToken cancellationToken, ISender mediator, ILogger<MinimalOrganisationEndPoints> logger) =>
+        app.MapGet("api/organisations", async ([FromQuery] long[] ids, [FromQuery] string? name, CancellationToken cancellationToken, ISender mediator, ILogger<MinimalOrganisationEndPoints> logger) =>
         {
             try
             {
-                var request = new ListOrganisationsCommand();
+                var request = new ListOrganisationsCommand(ids.ToList(), name);
                 var result = await mediator.Send(request, cancellationToken);
                 return result;
             }

--- a/tests/FamilyHubs.ServiceDirectory.Core.IntegrationTests/Organisations/WhenUsingGetOrganisationCommands.cs
+++ b/tests/FamilyHubs.ServiceDirectory.Core.IntegrationTests/Organisations/WhenUsingGetOrganisationCommands.cs
@@ -44,7 +44,7 @@ public class WhenUsingGetLocationCommands : DataIntegrationTestBase
         //Arrange
         await CreateOrganisationDetails();
 
-        var getCommand = new ListOrganisationsCommand();
+        var getCommand = new ListOrganisationsCommand(new List<long>(), null);
         var getHandler = new ListOrganisationCommandHandler(TestDbContext, Mapper);
 
         //Act


### PR DESCRIPTION
I want to be able to retrieve basic organisation info (not any related data ie. services, locations) but for specific organisations or organisations with a given name.

I've added query parameters to the existing list endpoint, more detailed data is still available in the get by id dedicated endpoint.