### PR TITLE
Fix age filter

### DIFF
--- a/src/FamilyHubs.ServiceDirectory.Core/Queries/Services/GetServices/GetServicesCommand.cs
+++ b/src/FamilyHubs.ServiceDirectory.Core/Queries/Services/GetServices/GetServicesCommand.cs
@@ -167,7 +167,7 @@ public class GetServicesCommandHandler : IRequestHandler<GetServicesCommand, Pag
         else if (request.GivenAge is not null)
         {
             query.And(
-                new StringCondition("e.MinimumAge < @GivenAge", new FhParameter("@GivenAge", request.GivenAge.Value))
+                new StringCondition("e.MinimumAge <= @GivenAge", new FhParameter("@GivenAge", request.GivenAge.Value))
             ).And(
                 new StringCondition("e.MaximumAge >= @GivenAge", new FhParameter("@GivenAge", request.GivenAge.Value))
             );


### PR DESCRIPTION
Fix off-by-one on age filter not matching lower bound of the service's age eligibility.